### PR TITLE
Redirect non-https requests for example heroku apps to https

### DIFF
--- a/example_oauth.rb
+++ b/example_oauth.rb
@@ -18,6 +18,10 @@ end
 
 enable :sessions
 
+before do
+  redirect request.url.sub('http', 'https') unless request.secure?
+end
+
 get '/' do
   erb :home
 end


### PR DESCRIPTION
If you land on http://litmus-oauth-example-staging.herokuapp.com via HTTP rather than HTTPS, then everything looks like it will behave, but clicking the "Connect with Litmus" link will throw an error `The redirect uri included is not valid.`

Added a `before` filter to redirect the page to `https` if a request for the `http` page comes in.